### PR TITLE
Remove the need to use npm 3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "elzar",
-  "version": "0.1.8-beta.4",
+  "version": "0.1.8-beta.5",
   "description": "resmio glamourous style guide in sass mode",
   "main": "index.js",
   "scripts": {
     "lint": "cd src && eslint . --ext .js --ext .jsx --fix --cache; exit 0",
     "test": "cd src/__tests__ && babel-node --presets es2015,react testSuite.js | faucet"
-  },
-  "engines": {
-    "npm": "~3.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It was causing a depnedency problem in th web app, ideally we should
put it there once we switch from bower to npm in the app
